### PR TITLE
Compatible with OAuth1 client method.

### DIFF
--- a/Server.php
+++ b/Server.php
@@ -102,7 +102,7 @@ class Server extends BaseServer
     /**
      * {@inheritdoc}
      */
-    public function getAuthorizationUrl($temporaryIdentifier)
+    public function getAuthorizationUrl($temporaryIdentifier, array $options = [])
     {
         // Somebody can pass through an instance of temporary
         // credentials and we'll extract the identifier from there.


### PR DESCRIPTION
```php
Declaration of SocialiteProviders\Twitter\Server::getAuthorizationUrl($temporaryIdentifier) should be compatible with League\OAuth1\Client\Server\Server::getAuthorizationUrl($temporaryIdentifier, array $options = Array)
```

`League\OAuth1\Client\Server\Server::getAuthorizationUrl` was changed paramater, added `$options` and when installing was failed, please merge it, thanks.