### PR TITLE
fixed error with declaration of Server::getAuthorizationUrl method

### DIFF
--- a/Server.php
+++ b/Server.php
@@ -102,17 +102,17 @@ class Server extends BaseServer
     /**
      * {@inheritdoc}
      */
-    public function getAuthorizationUrl($temporaryIdentifier)
+    public function getAuthorizationUrl($temporaryIdentifier, array $options = [])
     {
         // Somebody can pass through an instance of temporary
         // credentials and we'll extract the identifier from there.
         if ($temporaryIdentifier instanceof TemporaryCredentials) {
             $temporaryIdentifier = $temporaryIdentifier->getIdentifier();
         }
-        $query_oauth_token = ['oauth_token' => $temporaryIdentifier];
+        $queryOauthToken = ['oauth_token' => $temporaryIdentifier];
         $parameters = (isset($this->parameters))
-            ? array_merge($query_oauth_token, $this->parameters)
-            : $query_oauth_token;
+            ? array_merge($queryOauthToken, $this->parameters)
+            : $queryOauthToken;
 
         $url = $this->urlAuthorization();
         $queryString = http_build_query($parameters);


### PR DESCRIPTION
Declaration of method getAuthorizationUrl in Server class is incorrect. Missed $options argument. I copied the method from the current master branch. 

![image](https://user-images.githubusercontent.com/3227797/126223502-af5d398e-84b1-43ce-8ef5-d9501c492e5a.png)

Code of method getAuthorizationUrl in base server.

![image](https://user-images.githubusercontent.com/3227797/126223614-23a6e377-8da1-498b-b605-32e7df6aaa53.png)

I using laravel/socialite: v3.4.0. This is the last package version for laravel 5.5 (v5.5.50)