### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In Laravel 11, the default `EventServiceProvider` provider was removed. Instead,
 
 ```php
 Event::listen(function (\SocialiteProviders\Manager\SocialiteWasCalled $event) {
-    $event->extendSocialite('twitter', \SocialiteProviders\Twitter\Provider::class);
+    $event->extendSocialite('twitter', \SocialiteProviders\Twitter\Provider::class,  \SocialiteProviders\Twitter\Server::class);
 });
 ```
 <details>


### PR DESCRIPTION
Fix for compatibility issues with the latest socialite plugin and eliminating error "SocialiteProviders\Twitter\Provider does not extend Laravel\Socialite\Two\AbstractProvider"